### PR TITLE
Fix/SequenceEqual

### DIFF
--- a/dev/Modules/SequenceEqual.ts
+++ b/dev/Modules/SequenceEqual.ts
@@ -1,17 +1,18 @@
 Linq4JS.Helper.NonEnumerable("SequenceEqual", function<T> (this: T[], array: T[]): boolean {
-    if (this.Count() !== array.Count()) {
+    if (this === array) {
+        return true;
+    }
+    if (this == null || array == null) {
+        return false;
+    }
+    if (this.length !== array.length) {
         return false;
     }
 
     for (let i = 0; i < this.length; i++) {
-        let keys = Object.keys(this[i]);
-
-        for (let key of keys){
-            if ((this[i] as any)[key] !== (array[i] as any)[key]) {
-                return false;
-            }
+        if (this[i] !== array[i]) {
+            return false;
         }
     }
-
     return true;
 });

--- a/test/Tests/Modules/SequenceEqual.ts
+++ b/test/Tests/Modules/SequenceEqual.ts
@@ -4,4 +4,10 @@ describe("SequenceEqual", function(){
         expect(Users.SequenceEqual(Users.Skip(1))).toBeFalsy();
         expect(Users.SequenceEqual(<any>Fruits)).toBeFalsy();
     });
+
+    it("numbers", function() {
+        var source1 = [1, 2, 3];
+        var source2 = [1, 2, 4];
+        expect(source1.SequenceEqual(source2)).toBeFalsy();
+    });
 });


### PR DESCRIPTION
Fix for SequenceEqual.
Current implementation returns true for [1, 2, 3].SequenceEqual([1, 2, 4]).
Please review.